### PR TITLE
Switch to LangGraph-based memory

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -11,16 +11,7 @@ from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain.agents import create_tool_calling_agent, AgentExecutor
-
-try:  # LangChain >= 0.1.12
-    from langchain.memory import (
-        ConversationSummaryBufferMemory,
-        VectorStoreRetrieverMemory,
-        CombinedMemory,
-    )
-except ImportError:  # starší build
-    from langchain.memory.buffer import ConversationSummaryBufferMemory
-    from langchain.memory import VectorStoreRetrieverMemory, CombinedMemory
+from .langgraph_memory import LangGraphMemory
 
 from langchain.schema import Document
 from langchain_chroma import Chroma
@@ -111,20 +102,11 @@ prompt = ChatPromptTemplate.from_messages(
 # --------------------------------------------------------------------------- #
 # Paměti
 # --------------------------------------------------------------------------- #
-episodic_memory = ConversationSummaryBufferMemory(
-    llm=_summary_llm,
-    memory_key="chat_history",
-    return_messages=True,
-    max_token_limit=4000,
-    input_key="query",
-)
+episodic_memory = LangGraphMemory(memory_key="chat_history", input_key="query")
 
-long_term_memory = VectorStoreRetrieverMemory(
-    retriever=_memory_store.as_retriever(search_kwargs={"k": 5}),
-    memory_key="long_term_memory",
-)
-
-memory = CombinedMemory(memories=[episodic_memory, long_term_memory])
+def _retrieve_long_term(query: str) -> str:
+    docs = _memory_store.as_retriever(search_kwargs={"k": 5}).invoke(query)
+    return "\n".join(doc.page_content for doc in docs)
 
 # --------------------------------------------------------------------------- #
 # Agent a nástroje
@@ -149,7 +131,7 @@ _agent = create_tool_calling_agent(llm=_llm, prompt=prompt, tools=_TOOLS)
 agent_executor = AgentExecutor(
     agent=_agent,
     tools=_TOOLS,
-    memory=memory,
+    memory=episodic_memory,
     verbose=True,
     return_intermediate_steps=True,
 )
@@ -171,7 +153,8 @@ def _store_exchange(question: str, answer: str) -> None:
 # Veřejné API
 # --------------------------------------------------------------------------- #
 def handle_query(query: str) -> str:
-    raw = agent_executor.invoke({"query": query})
+    long_term = _retrieve_long_term(query)
+    raw = agent_executor.invoke({"query": query, "long_term_memory": long_term})
     full = next(
         (
             obs

--- a/agent/langgraph_memory.py
+++ b/agent/langgraph_memory.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List
+from uuid import uuid4
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, get_buffer_string
+from langchain.memory.chat_memory import BaseChatMemory
+from langgraph.checkpoint.memory import MemorySaver
+
+class LangGraphMemory(BaseChatMemory):
+    """Simple conversation memory backed by LangGraph's MemorySaver."""
+
+    def __init__(
+        self,
+        *,
+        memory_key: str = "chat_history",
+        input_key: str = "query",
+        return_messages: bool = True,
+        thread_id: str = "default",
+    ) -> None:
+        super().__init__()
+        self.memory_key = memory_key
+        self.input_key = input_key
+        self.return_messages = return_messages
+        self.thread_id = thread_id
+        self._saver = MemorySaver()
+        self._messages: List[dict] = []
+
+    @property
+    def memory_variables(self) -> List[str]:
+        return [self.memory_key]
+
+    def _load(self) -> None:
+        cfg = {"configurable": {"thread_id": self.thread_id}}
+        ck = self._saver.get_tuple(cfg)
+        if ck:
+            self._messages = ck.checkpoint["channel_values"].get("messages", [])
+
+    def load_memory_variables(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        self._load()
+        msgs: List[BaseMessage] = [
+            HumanMessage(content=m["content"]) if m["role"] == "user" else AIMessage(content=m["content"])
+            for m in self._messages
+        ]
+        if self.return_messages:
+            return {self.memory_key: msgs}
+        return {self.memory_key: get_buffer_string(msgs)}
+
+    def save_context(self, inputs: dict[str, Any], outputs: dict[str, str]) -> None:
+        self._load()
+        self._messages.extend([
+            {"role": "user", "content": inputs[self.input_key]},
+            {"role": "assistant", "content": outputs.get("output", "")},
+        ])
+        ck = {
+            "v": 1,
+            "id": str(uuid4()),
+            "ts": datetime.utcnow().isoformat(),
+            "channel_values": {"messages": self._messages},
+            "channel_versions": {"messages": self._saver.get_next_version(None, None)},
+            "versions_seen": {},
+        }
+        self._saver.put(
+            {"configurable": {"thread_id": self.thread_id, "checkpoint_ns": "", "checkpoint_id": ck["id"]}},
+            ck,
+            {},
+            ck["channel_versions"],
+        )
+
+    def clear(self) -> None:
+        self._messages = []
+        self._saver.delete_thread(self.thread_id)

--- a/jira_client.py
+++ b/jira_client.py
@@ -1,0 +1,15 @@
+from langchain_openai import OpenAIEmbeddings
+from services.jira_service import (
+    JiraClient,
+    JiraClientError,
+    find_duplicate_ideas,
+    _extract_text_from_adf,
+)
+
+__all__ = [
+    "JiraClient",
+    "JiraClientError",
+    "find_duplicate_ideas",
+    "_extract_text_from_adf",
+    "OpenAIEmbeddings",
+]

--- a/services/jira_service.py
+++ b/services/jira_service.py
@@ -54,7 +54,7 @@ def _extract_text_from_adf(adf: Any) -> str:
     stack: List[Any] = [adf]
     parts: List[str] = []
     while stack:
-        n = stack.pop()
+        n = stack.pop(0)
         if isinstance(n, dict):
             if n.get("type") == "text" and "text" in n:
                 parts.append(n["text"])
@@ -111,6 +111,9 @@ class JiraClient:  # pylint: disable=too-few-public-methods
                 if delay is None:
                     raise JiraClientError(str(exc)) from exc
                 time.sleep(delay)
+
+    # Backwards-compat shim for tests
+    _call_with_retry = _call
 
     # ------------------------------------------------------------------ public
     def search_issues(


### PR DESCRIPTION
## Summary
- implement new `LangGraphMemory` with `MemorySaver`
- replace deprecated LangChain memory in agent core
- expose `jira_client` wrapper
- adjust Jira service ADF helper and compatibility layer

## Testing
- `pytest -q` *(fails: Connection refused, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_b_686798bc78c483309f1f8ced6e16a6a2