### PR TITLE
Use unified CHROMA_DIR_V2 setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ venv/
 *.log
 
 # Vector db
-rag_chroma_db/
 data/
 
 output/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ README.md file that needsy to be updated accordingly to current project state an
 | Category                      | Status          | Details                                                                                                                 |
 | ----------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | **Conversational interface**  | **✅**           | CLI (`main.py`) **and** lightweight Gradio UI (`ui.py`).                                                                |
-| **Knowledge retrieval (RAG)** | **✅**           | Chroma vector‑store (`rag_chroma_db/`) continuously enriched with every Q\&A turn.                                      |
+| **Knowledge retrieval (RAG)** | **✅**           | Chroma vector‑store (default `./data/`, configurable via `CHROMA_DIR_V2`) continuously enriched with every Q\&A turn.                                      |
 | **Web search**                | **✅**           | DuckDuckGo (`searchWeb`) & Wikipedia snippet tool.                                                                      |
 | **Semantic web search**       | **β**           | Tavily semantic search if `TAVILY_API_KEY` is present.                                                                  |
 | **Jira integration**          | **✅**           | `jira_ideas_retriever` – lists *Idea* issues matching an optional keyword.                                              |
@@ -95,7 +95,7 @@ TAVILY_API_KEY=""           # optional
 ├── rag_confluence_loader.py  # import Confluence pages into RAG
 ├── rag_vectorstore.py     # bulk‑import local docs into RAG
 ├── output/                # timestamped txt exports (git‑ignored)
-└── rag_chroma_db/         # vector DB (git‑ignored)
+└── data/                # vector DB (path via $CHROMA_DIR_V2)
 ```
 
 ---

--- a/agent/core.py
+++ b/agent/core.py
@@ -47,7 +47,7 @@ if hasattr(openai, "telemetry") and hasattr(openai.telemetry, "TelemetryClient")
 # ---------------------------------------------------------------------------
 # Vectorstore (RAG) setup
 # ---------------------------------------------------------------------------
-CHROMA_DIR = "rag_chroma_db"
+CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
 _embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
 _vectorstore = Chroma(persist_directory=CHROMA_DIR, embedding_function=_embeddings)
 

--- a/clear_rag_memory.py
+++ b/clear_rag_memory.py
@@ -3,7 +3,8 @@
 clear_rag_memory.py
 ===================
 
-Jednorázové promazání a/nebo validace Chroma DB ('rag_chroma_db/') používané jako RAG paměť.
+Jednorázové promazání a/nebo validace Chroma DB (adresář daný `CHROMA_DIR_V2`,
+výchozí `data/`) používané jako RAG paměť.
 
 • Smaže nebo zazálohuje DB a ověří, že po operaci nezůstaly žádné vektory.
 • Závislost na 'chromadb' je volitelná – bez ní proběhne fallback validace přes velikost souborů.
@@ -25,6 +26,7 @@ Pouhá kontrola (např. v CI)
 from __future__ import annotations
 
 import argparse
+import os
 import datetime as _dt
 import pathlib as _pl
 import shutil as _sh
@@ -37,7 +39,7 @@ except ImportError:  # pragma: no cover
     chromadb = None  # type: ignore
 
 ROOT = _pl.Path(__file__).resolve().parent
-DB_DIR = ROOT / "rag_chroma_db"
+DB_DIR = ROOT / os.getenv("CHROMA_DIR_V2", "data")
 
 
 # ------------------------------------------------------------------------------
@@ -83,9 +85,9 @@ def _validate_empty() -> bool:
 # ------------------------------------------------------------------------------
 
 def _wipe_rag_db(force: bool, backup: bool) -> None:
-    """Smaže nebo zálohuje adresář rag_chroma_db/ a pak jej znovu vytvoří."""
+    """Smaže nebo zálohuje adresář daný `CHROMA_DIR_V2` a pak jej znovu vytvoří."""
     if not DB_DIR.exists():
-        print("Adresář 'rag_chroma_db' neexistuje – RAG paměť je už prázdná.")
+        print(f"Adresář '{DB_DIR.name}' neexistuje – RAG paměť je už prázdná.")
         return
 
     if not force:
@@ -96,7 +98,7 @@ def _wipe_rag_db(force: bool, backup: bool) -> None:
 
     if backup:
         stamp = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
-        dest = DB_DIR.with_name(f"rag_chroma_db_backup_{stamp}")
+        dest = DB_DIR.with_name(f"{DB_DIR.name}_backup_{stamp}")
         _sh.move(str(DB_DIR), dest)
         print(f"Vektorová DB byla přesunuta do: {dest}")
     else:
@@ -104,7 +106,7 @@ def _wipe_rag_db(force: bool, backup: bool) -> None:
         print("Vektorová DB byla nenávratně smazána.")
 
     DB_DIR.mkdir(exist_ok=True)
-    print("Vytvořen nový prázdný 'rag_chroma_db'.")
+    print(f"Vytvořen nový prázdný '{DB_DIR.name}'.")
 
 
 # ------------------------------------------------------------------------------

--- a/merge_project.py
+++ b/merge_project.py
@@ -4,7 +4,8 @@ import os
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))  # Hlavní složka projektu
 OUTPUT_FILE = os.path.join(ROOT_DIR, "project_snapshot.md")
 
-EXCLUDE_FOLDERS = {'.git', '__pycache__', '.venv', 'venv', 'input','output', 'rag_chroma_db'}
+CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
+EXCLUDE_FOLDERS = {'.git', '__pycache__', '.venv', 'venv', 'input', 'output', CHROMA_DIR, 'rag_chroma_db'}
 EXCLUDE_FILES = {'project_snapshot.md', 'merge_project.py', '.env', '.png'}
 
 def should_exclude(path: str, exclude_set: set) -> bool:

--- a/rag_confluence_loader.py
+++ b/rag_confluence_loader.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 # ── Suppress Chroma telemetry errors ──────────────────────────────────────────
 # Must be set before importing Chroma
 os.environ["CHROMA_TELEMETRY"] = "0"
+CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
 
 from langchain_community.document_loaders import ConfluenceLoader
 from langchain_openai import OpenAIEmbeddings
@@ -55,7 +56,7 @@ def main():
     # ── Prepare embeddings & vectorstore ────────────────────────────────────────
     embeddings = OpenAIEmbeddings()
     vectorstore = Chroma(
-        persist_directory="rag_chroma_db",
+        persist_directory=CHROMA_DIR,
         embedding_function=embeddings
     )
 

--- a/services/input_loader.py
+++ b/services/input_loader.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 from pathlib import Path
+import os
 from typing import List
 
 from langchain_chroma import Chroma
@@ -30,7 +31,7 @@ from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_community.vectorstores.utils import filter_complex_metadata
 
 # ---- konfigurace -----------------------------------------------------------
-CHROMA_DIR = "rag_chroma_db"
+CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
 INPUT_DIR = Path("input")
 INPUT_DIR.mkdir(exist_ok=True)
 

--- a/services/rag_service.py
+++ b/services/rag_service.py
@@ -17,6 +17,7 @@ from langchain.schema import Document
 
 
 # ───────────────────────── Helper: Robust TXT Saver ───────────────────────────
+CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
 OUTPUT_DIR = Path("output")
 OUTPUT_DIR.mkdir(exist_ok=True)
 
@@ -32,7 +33,7 @@ def save_text_to_file(data: str, prefix: str = "research") -> str:
 
 # ───────────────────────── Vector store builder ─────────────────────────────--
 
-def build_vectorstore(docs_path: str = "./data", persist_directory: str = "rag_chroma_db") -> None:
+def build_vectorstore(docs_path: str = "./data", persist_directory: str = CHROMA_DIR) -> None:
     """Create a Chroma vector store from text documents."""
     load_dotenv()
     loader = DirectoryLoader(docs_path, glob="**/*.txt")
@@ -44,7 +45,6 @@ def build_vectorstore(docs_path: str = "./data", persist_directory: str = "rag_c
 
 
 # ───────────────────────── RAG Retriever over Chroma ─────────────────────────-
-CHROMA_DIR = "rag_chroma_db"
 _embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
 _retriever = Chroma(persist_directory=CHROMA_DIR, embedding_function=_embeddings).as_retriever(search_kwargs={"k": 4})
 

--- a/tools/rag_tools.py
+++ b/tools/rag_tools.py
@@ -17,6 +17,7 @@ if hasattr(openai, "telemetry") and hasattr(openai.telemetry, "TelemetryClient")
     openai.telemetry.TelemetryClient.capture = lambda *_, **__: None
 
 # ───────────────────────── Helper: Robust TXT Saver ──────────────────────────
+CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
 OUTPUT_DIR = Path("output")
 OUTPUT_DIR.mkdir(exist_ok=True)
 
@@ -61,7 +62,6 @@ save_tool = Tool(
 )
 
 # ───────────────────────── RAG Retriever over Chroma ─────────────────────────
-CHROMA_DIR = "rag_chroma_db"
 _embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
 _retriever = Chroma(persist_directory=CHROMA_DIR, embedding_function=_embeddings).as_retriever(search_kwargs={"k": 4})
 


### PR DESCRIPTION
## Summary
- default to `os.getenv("CHROMA_DIR_V2", "data")` across RAG tools and services
- document the new environment variable in README
- clean up old `rag_chroma_db` references and update `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e45b0c7688330a1a31b18522c6ad8