### PR TITLE
Add optional filename to save_text_to_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Conversational assistant tailored for **Productoo's P4** platform. It leverages 
 | `rag_retriever`        | Fetch up to 4 most relevant chunks from the internal vector store (docs, roadmap, chats). |
 | `jira_ideas_retriever` | List *Ideas* from Jira project **P4**; optional `keyword` filter.                         |
 | `tavily_search`        | LLM‑powered semantic web search (requires `TAVILY_API_KEY`).                              |
-| `save_text_to_file`    | Persist any text to `output/…` (timestamped).                                             |
+| `save_text_to_file`    | Persist any text to `output/…`; allows custom filename or timestamped default. |
 | `kb_loader`            | Import Confluence pages and new files from `input/` into the long‑term knowledge base. |
 
 > **Planned tool** – `jira_issue_detail`: fetch a **single** Jira issue by key (e.g. `P4‑1234`) with full description, acceptance criteria, subtasks & comments.

--- a/services/rag_service.py
+++ b/services/rag_service.py
@@ -22,11 +22,22 @@ OUTPUT_DIR = Path("output")
 OUTPUT_DIR.mkdir(exist_ok=True)
 
 
-def save_text_to_file(data: str, prefix: str = "research") -> str:
-    """Save *data* into a new TXT file and report the path."""
+def save_text_to_file(
+    data: str,
+    prefix: str = "research",
+    filename: str | None = None,
+) -> str:
+    """Save *data* into a new TXT file and report the path.
+
+    If *filename* is provided, it will be used (``.txt`` appended when missing).
+    Otherwise a name ``<prefix>_YYYY-MM-DD_HH-MM-SS.txt`` is generated.
+    """
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    filename = f"{prefix}_{timestamp}.txt"
-    path = OUTPUT_DIR / filename
+    if filename:
+        base = filename if filename.endswith(".txt") else f"{filename}.txt"
+    else:
+        base = f"{prefix}_{timestamp}.txt"
+    path = OUTPUT_DIR / base
     path.write_text(data, encoding="utf-8")
     return f"Data saved to {path.as_posix()}"
 

--- a/tools/rag_tools.py
+++ b/tools/rag_tools.py
@@ -22,11 +22,29 @@ OUTPUT_DIR = Path("output")
 OUTPUT_DIR.mkdir(exist_ok=True)
 
 
-def _save_to_txt(data: str, prefix: str = "research") -> str:
-    """Save *data* into a new TXT file and report the path."""
+def _save_to_txt(
+    data: str,
+    prefix: str = "research",
+    filename: str | None = None,
+) -> str:
+    """Save *data* into a new TXT file and report the path.
+
+    Parameters
+    ----------
+    data : str
+        The text content to persist.
+    prefix : str, optional
+        Fallback prefix if *filename* is not provided.
+    filename : str | None, optional
+        Explicit file name (with or without ``.txt`` extension).
+    """
+
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    filename = f"{prefix}_{timestamp}.txt"
-    path = OUTPUT_DIR / filename
+    if filename:
+        base = filename if filename.endswith(".txt") else f"{filename}.txt"
+    else:
+        base = f"{prefix}_{timestamp}.txt"
+    path = OUTPUT_DIR / base
     path.write_text(data, encoding="utf-8")
     return f"Data saved to {path.as_posix()}"
 
@@ -44,9 +62,11 @@ save_tool = Tool(
 
         Parameters
         ----------
-        data   : str   (required) – the full body of text to save.
-        prefix : str   (optional, default "research") – filename prefix; the final name
-                is <prefix>_YYYY-MM-DD_HH-MM-SS.txt.
+        data      : str   (required) – the full body of text to save.
+        prefix    : str   (optional, default "research") – fallback prefix for auto naming.
+        filename  : str   (optional) – desired file name; ``.txt`` will be appended
+                if missing. When omitted, the name defaults to
+                ``<prefix>_YYYY-MM-DD_HH-MM-SS.txt``.
 
         Returns
         -------


### PR DESCRIPTION
## Summary
- allow custom filename for `save_text_to_file`
- document new behaviour in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687f55a826a483309139ff261c76be1e