### PR TITLE
Update pruning condition in learn()

### DIFF
--- a/agent/core2.py
+++ b/agent/core2.py
@@ -411,7 +411,8 @@ def learn(state: AgentState) -> AgentState:
 
     try:
         total = _chat_store.get_total_records()
-        if total > MAX_CHAT_RECORDS:
+        # Defer costly sort/delete until we exceed the limit by a margin
+        if total > MAX_CHAT_RECORDS + 500:
             over = total - MAX_CHAT_RECORDS
             res = _chat_store.get(include=["metadatas"], limit=None)
             records = list(zip(res["ids"], res["metadatas"]))


### PR DESCRIPTION
## Summary
- delay expensive chat log pruning logic to run only when buffer is exceeded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687f5ea07cec8330893008c0092426dd