### PR TITLE
Use shorter retrieval for short queries

### DIFF
--- a/agent/core2.py
+++ b/agent/core2.py
@@ -321,7 +321,9 @@ def recall(state: AgentState) -> AgentState:
     use_kb = _is_information_query(query) or since_last > QUERY_TIME_THRESHOLD
     store = _kb_store if use_kb else _chat_store
 
-    results = store.similarity_search_with_relevance_scores(query, k=4)
+    words = len(query.split())
+    k = 2 if words < 10 else 4
+    results = store.similarity_search_with_relevance_scores(query, k=k)
     reranked: list[tuple[float, Document]] = []
     now_ts = datetime.utcnow().timestamp()
     for doc, cos in results:


### PR DESCRIPTION
## Summary
- tweak `recall` in `core2.py` to pick 2 documents for short queries

## Testing
- `pytest -q`
- `python -m py_compile agent/core2.py`


------
https://chatgpt.com/codex/tasks/task_b_687f66aae9b88330b2252f9283d8733c