### PR TITLE
Unify input and output folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ data/
 data/*
 !data/persistent_chat_history.json
 
-output/
+files/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Conversational assistant tailored for **Productoo's P4** platform. It leverages 
 | **Web search** | DuckDuckGo and Wikipedia snippets with optional semantic search via Tavily. |
 | **Jira integration** | Tools for listing Ideas, fetching issue detail, checking duplicates and updating descriptions. |
 | **Content generators** | Create Jira Ideas, Epics and User Stories from short prompts. |
-| **File ingestion** | Drop files into `./input` and import them with `process_input_files` or `kb_loader`. |
+| **File ingestion** | Drop files into `./files` and import them with `process_input_files` or `kb_loader`. |
 | **Persistent memory** | Chat history saved to `data/persistent_chat_history.json` and stored in the vector DB. |
 
 ---
@@ -27,10 +27,10 @@ Conversational assistant tailored for **Productoo's P4** platform. It leverages 
 | `rag_retriever`        | Fetch up to 4 most relevant chunks from the internal vector store (docs, roadmap, chats). |
 | `jira_ideas_retriever` | List *Ideas* from Jira project **P4**; optional `keyword` filter.                         |
 | `tavily_search`        | LLM‑powered semantic web search (requires `TAVILY_API_KEY`).                              |
-| `save_text_to_file`    | Persist any text to `output/…`; allows custom filename or timestamped default. |
-| `list_output_files`    | Show available `.txt`, `.md`, `.csv` and `.pdf` files saved under `output/`. |
-| `read_output_file`     | Read the contents of a chosen file from `output/`. |
-| `kb_loader`            | Import Confluence pages and new files from `input/` into the long‑term knowledge base. |
+| `save_text_to_file`    | Persist any text to `files/…`; allows custom filename or timestamped default. |
+| `list_output_files`    | Show available `.txt`, `.md`, `.csv` and `.pdf` files saved under `files/`. |
+| `read_output_file`     | Read the contents of a chosen file from `files/`. |
+| `kb_loader`            | Import Confluence pages and new files from `files/` into the long‑term knowledge base. |
 
 > **Planned tool** – `jira_issue_detail`: fetch a **single** Jira issue by key (e.g. `P4‑1234`) with full description, acceptance criteria, subtasks & comments.
 > *Benefit:* quick deep‑dives, faster duplicate detection.
@@ -92,8 +92,7 @@ cli/                  # CLI and Gradio UI entry points
 services/             # Business logic for Jira, RAG and web search
 tools/                # LangChain tool wrappers
 prompts/              # Jinja2 templates for Jira content generators
-input/                # Drop-box for user files
-output/               # Saved answers (git‑ignored)
+ files/                # Shared space for user uploads and saved answers
 ```
 
 ---

--- a/cli/ui.py
+++ b/cli/ui.py
@@ -25,15 +25,15 @@ warnings.filterwarnings("ignore", message=".*LangChainDeprecationWarning.*")
 os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "false")
 
 # Constants
-OUTPUT_DIR = pathlib.Path("output")
-OUTPUT_DIR.mkdir(exist_ok=True)
+FILES_DIR = pathlib.Path("files")
+FILES_DIR.mkdir(exist_ok=True)
 MAX_HISTORY_LENGTH = 50  # Limit chat history to prevent memory issues
 
 
 def list_files() -> List[str]:
-    """Get sorted list of files in output directory."""
+    """Get sorted list of files in the shared directory."""
     try:
-        return sorted(p.name for p in OUTPUT_DIR.iterdir() if p.is_file())
+        return sorted(p.name for p in FILES_DIR.iterdir() if p.is_file())
     except Exception as e:
         logger.error(f"Error listing files: {e}")
         return []
@@ -44,7 +44,7 @@ def read_file(fname: str) -> str:
     if not fname:
         return ""
 
-    path = OUTPUT_DIR / fname
+    path = FILES_DIR / fname
     try:
         return path.read_text("utf-8")
     except UnicodeDecodeError:
@@ -57,10 +57,10 @@ def read_file(fname: str) -> str:
 
 
 def file_path(fname: Optional[str]) -> Optional[str]:
-    """Return full path to output file, or None if not specified."""
+    """Return full path to file in ``files`` or ``None`` if not specified."""
     if not fname:
         return None
-    p = OUTPUT_DIR / fname
+    p = FILES_DIR / fname
     return str(p) if p.exists() else None
 
 

--- a/input/novy_test.txt
+++ b/input/novy_test.txt
@@ -1,3 +1,0 @@
-this is new file for testing inmport files tool.
-
-The main message of this file is "Crysis is the best".

--- a/input/testing_input_file.txt
+++ b/input/testing_input_file.txt
@@ -1,3 +1,0 @@
-this is a testing input file.
-Date created = 1.7.2025 8:25
-"Call me Ishmael"

--- a/services/input_loader.py
+++ b/services/input_loader.py
@@ -1,9 +1,9 @@
 # services/input_loader.py
 
 """
-Input Loader – import files from ./input do Chroma vektorové DB
+Input Loader – import files from ./files do Chroma vektorové DB
 ---------------------------------------------------------------
-➤ Přetahuje soubory z lokální složky `./input` (případně podmnožinu podle
+➤ Přetahuje soubory z lokální složky `./files` (případně podmnožinu podle
   argumentu) a indexuje je pro RAG dotazy.
 
 Argumenty (string):
@@ -32,7 +32,7 @@ from langchain_community.vectorstores.utils import filter_complex_metadata
 
 # ---- konfigurace -----------------------------------------------------------
 CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
-INPUT_DIR = Path("input")
+INPUT_DIR = Path("files")
 INPUT_DIR.mkdir(exist_ok=True)
 
 _embeddings = OpenAIEmbeddings(model="text-embedding-3-small")

--- a/services/kb_loader.py
+++ b/services/kb_loader.py
@@ -18,7 +18,7 @@ from langchain_unstructured import UnstructuredLoader
 from langchain_community.vectorstores.utils import filter_complex_metadata
 
 CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
-INPUT_DIR = Path("input")
+INPUT_DIR = Path("files")
 INPUT_DIR.mkdir(exist_ok=True)
 
 _embeddings = OpenAIEmbeddings(model="text-embedding-3-small")

--- a/services/output_reader.py
+++ b/services/output_reader.py
@@ -1,28 +1,28 @@
 from __future__ import annotations
 
-"""Utilities for listing and reading files in the ``output`` folder."""
+"""Utilities for listing and reading files in the ``files`` folder."""
 
 from pathlib import Path
 
 from langchain_unstructured import UnstructuredLoader
 
-OUTPUT_DIR = Path("output")
+OUTPUT_DIR = Path("files")
 OUTPUT_DIR.mkdir(exist_ok=True)
 
 ALLOWED_EXTS = {".txt", ".md", ".csv", ".pdf"}
 
 
 def list_output_files() -> str:
-    """Return Markdown-formatted list of available output files."""
+    """Return Markdown-formatted list of available files."""
     files = [p.name for p in OUTPUT_DIR.iterdir() if p.is_file() and p.suffix.lower() in ALLOWED_EXTS]
     if not files:
-        return "Žádné soubory ve složce output nenalezeny."
+        return "Žádné soubory ve složce files nenalezeny."
     lines = [f"- {name}" for name in sorted(files)]
     return "\n".join(lines)
 
 
 def read_output_file(name: str) -> str:
-    """Return textual content of *name* from ``output`` if supported."""
+    """Return textual content of *name* from ``files`` if supported."""
     name = name.strip()
     if not name:
         return "Nebyl zadán název souboru."

--- a/services/rag_service.py
+++ b/services/rag_service.py
@@ -18,7 +18,7 @@ from langchain.schema import Document
 
 # ───────────────────────── Helper: Robust TXT Saver ───────────────────────────
 CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
-OUTPUT_DIR = Path("output")
+OUTPUT_DIR = Path("files")
 OUTPUT_DIR.mkdir(exist_ok=True)
 
 

--- a/tools/input_loader.py
+++ b/tools/input_loader.py
@@ -21,7 +21,7 @@ process_input_tool = Tool(
         """
         Purpose
         -------
-        Scan the local **`./input`** drop-folder, import every file that matches the
+        Scan the local **`./files`** drop-folder, import every file that matches the
         given filter into the Chroma vector database so RAG queries can reference
         them, and return a one-sentence Markdown summary per file.
 

--- a/tools/kb_tools.py
+++ b/tools/kb_tools.py
@@ -16,7 +16,7 @@ kb_loader_tool = Tool(
     coroutine=_update_kb,
     description=(
         "Synchronise the long-term knowledge base (`kb_docs`) with data from "
-        "Confluence and files dropped in `./input`.\n"
+        "Confluence and files dropped in `./files`.\n"
         "Call without arguments to load both sources.\n"
         "Use 'confluence' to sync only Confluence pages or 'files' (optionally "
         "'files:<filter>') to import local files. The filter accepts the same"

--- a/tools/output_reader.py
+++ b/tools/output_reader.py
@@ -1,4 +1,4 @@
-"""LangChain tools for listing and reading files from the output folder."""
+"""LangChain tools for listing and reading files from the shared folder."""
 from __future__ import annotations
 
 from langchain.tools import Tool
@@ -17,7 +17,7 @@ list_output_files_tool = Tool(
     name="list_output_files",
     func=_list,
     description=(
-        "Return names of files stored under ./output/ with extensions txt, md, csv or pdf."
+        "Return names of files stored under ./files/ with extensions txt, md, csv or pdf."
     ),
     handle_tool_error=True,
 )
@@ -26,7 +26,7 @@ read_output_file_tool = Tool(
     name="read_output_file",
     func=_read,
     description=(
-        "Read the content of a specific file from ./output/. The argument must be an existing file name."
+        "Read the content of a specific file from ./files/. The argument must be an existing file name."
     ),
     handle_tool_error=True,
 )

--- a/tools/rag_tools.py
+++ b/tools/rag_tools.py
@@ -20,7 +20,7 @@ if hasattr(openai, "telemetry") and hasattr(openai.telemetry, "TelemetryClient")
 
 # ───────────────────────── Helper: Robust TXT Saver ──────────────────────────
 CHROMA_DIR = os.getenv("CHROMA_DIR_V2", "data")
-OUTPUT_DIR = Path("output")
+OUTPUT_DIR = Path("files")
 OUTPUT_DIR.mkdir(exist_ok=True)
 
 
@@ -58,7 +58,7 @@ save_tool = Tool(
         """
         Purpose
         -------
-        Persist any piece of plain text to a timestamped *.txt* file under ./output/.
+        Persist any piece of plain text to a timestamped *.txt* file under ./files/.
         Ideal for jotting down idea drafts, SWOT analyses, user-stories, or scratch notes
         that you might want to share later.
 


### PR DESCRIPTION
## Summary
- use a single `files/` directory for uploads and saved answers
- update services and tools to reference the new folder
- refresh README instructions for the shared folder
- clean up CLI UI paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688088ff785883308cd408cba570874b