### PR TITLE
Enable file editing in Gradio UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Conversational assistant tailored for **Productoo's P4** platform. It leverages 
 | **Jira integration** | Tools for listing Ideas, fetching issue detail, checking duplicates and updating descriptions. |
 | **Content generators** | Create Jira Ideas, Epics and User Stories from short prompts. |
 | **File ingestion** | Drop files into `./files` and import them with `process_input_files` or `kb_loader`. |
+| **File editing** | Edit and rename text files directly from the web UI. |
 | **Persistent memory** | Chat history saved to `data/persistent_chat_history.json` and stored in the vector DB. |
 
 ---


### PR DESCRIPTION
## Summary
- allow editing file name and content in the web UI
- persist changes and refresh dropdown when saving
- document new editing feature in README

## Testing
- `python -m py_compile cli/ui.py`

------
https://chatgpt.com/codex/tasks/task_b_68808e14e12083308a97d4d0a75a5170