### PR TITLE
Integrate self‑inspection tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Conversational assistant tailored for **Productoo's P4** platform. It leverages 
 | `list_output_files`    | Show available `.txt`, `.md`, `.csv` and `.pdf` files saved under `files/`. |
 | `read_output_file`     | Read the contents of a chosen file from `files/`. |
 | `kb_loader`            | Import Confluence pages and new files from `files/` into the long‑term knowledge base. |
+| `self_inspection`      | Summarize the agent's own architecture and current abilities. |
 
 > **Planned tool** – `jira_issue_detail`: fetch a **single** Jira issue by key (e.g. `P4‑1234`) with full description, acceptance criteria, subtasks & comments.
 > *Benefit:* quick deep‑dives, faster duplicate detection.

--- a/agent/core.py
+++ b/agent/core.py
@@ -113,6 +113,7 @@ from tools import (
     jira_issue_links,
     kb_loader_tool,
     clear_rag_memory_tool,
+    self_inspection_tool,
 )
 
 # ---------------------------------------------------------------------------
@@ -387,6 +388,7 @@ _TOOLS = [
     jira_issue_links,
     kb_loader_tool,
     clear_rag_memory_tool,
+    self_inspection_tool,
 ]
 _TOOLS = list(map(_safe, _TOOLS))
 

--- a/services/self_inspection.py
+++ b/services/self_inspection.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
 
+__all__ = ["agent_introspect"]
+
 def generate_project_snapshot(root_dir: Path) -> str:
     # Inspirace merge_project.py
     result = StringIO()
@@ -33,9 +35,10 @@ def summarize_agent(snapshot: str) -> str:
     chain = prompt | llm
     return chain.invoke({"snapshot": snapshot}).content
 
-def agent_introspect_tool() -> str:
+def agent_introspect() -> str:
+    """Return a short high level summary of this project."""
     root = Path(__file__).parent.parent  # root of project
     snapshot = generate_project_snapshot(root)
     summary = summarize_agent(snapshot)
     timestamp = datetime.now().isoformat()
-    return f"#Agent Introspection ({timestamp})\n\n{summary}"
+    return f"# Agent Introspection ({timestamp})\n\n{summary}"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -19,6 +19,7 @@ from .input_loader import process_input_tool
 from .kb_tools import kb_loader_tool
 from .memory_tools import clear_rag_memory_tool
 from .output_reader import list_output_files_tool, read_output_file_tool
+from .self_inspection_tool import self_inspection_tool
 
 __all__ = [
     "search_tool",
@@ -38,6 +39,7 @@ __all__ = [
     "jira_issue_links",
     "kb_loader_tool",
     "clear_rag_memory_tool",
+    "self_inspection_tool",
     "list_output_files_tool",
     "read_output_file_tool",
 ]

--- a/tools/self_inspection_tool.py
+++ b/tools/self_inspection_tool.py
@@ -1,1 +1,18 @@
-# tools/self_inspection_tool.py
+"""LangChain tool exposing services.self_inspection.agent_introspect."""
+from __future__ import annotations
+
+from langchain.tools import Tool
+
+from services.self_inspection import agent_introspect
+
+
+self_inspection_tool = Tool(
+    name="self_inspection",
+    func=lambda: agent_introspect(),
+    description=(
+        "Provide a concise summary of the agent's architecture, capabilities and limitations."
+    ),
+    handle_tool_error=True,
+)
+
+__all__ = ["self_inspection_tool"]


### PR DESCRIPTION
## Summary
- implement introspection in `services/self_inspection.py`
- expose new `self_inspection_tool`
- export tool via `tools/__init__.py`
- include tool in the LangChain agent
- document tool in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880d5502d548330afa6df52a9f385d3