### PR TITLE
standardize service-tool links

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -15,6 +15,9 @@ from .jira_content_service import (
 )
 from .input_loader import process_input_files
 from .output_reader import list_output_files, read_output_file
+from .kb_loader import update_kb
+from .clear_rag_memory import clear_memory
+from .self_inspection import agent_introspect
 
 __all__ = [
     "JiraClient",
@@ -28,8 +31,13 @@ __all__ = [
     "wiki_snippet",
     "tavily_search",
     "_extract_text_from_adf",
-    "jira_content_tools",
     "process_input_files",
+    "update_kb",
+    "clear_memory",
+    "agent_introspect",
     "list_output_files",
     "read_output_file",
+    "enhance_idea",
+    "epic_from_idea",
+    "user_stories_for_epic",
 ]

--- a/tools/input_loader.py
+++ b/tools/input_loader.py
@@ -6,7 +6,7 @@ Wrapper, který zpracuje volitelný `arg` od agenta a přepošle ho do služebn�
 funkce.  Díky tomu může agent jemně řídit import (viz docstring v services).
 """
 from langchain.tools import Tool
-from services.input_loader import process_input_files
+from services import process_input_files
 
 
 def _process_input_files(arg: str = "") -> str:

--- a/tools/jira_content_tools.py
+++ b/tools/jira_content_tools.py
@@ -25,7 +25,7 @@ import asyncio
 from langchain.tools import StructuredTool
 from pydantic import BaseModel, Field
 
-from services.jira_content_service import (
+from services import (
     enhance_idea as _enhance_idea,
     epic_from_idea as _epic_from_idea,
     user_stories_for_epic as _user_stories_for_epic,

--- a/tools/kb_tools.py
+++ b/tools/kb_tools.py
@@ -1,6 +1,6 @@
 """LangChain Tool for updating the kb_docs memory."""
 from langchain.tools import Tool
-from services.kb_loader import update_kb
+from services import update_kb
 import asyncio
 
 

--- a/tools/memory_tools.py
+++ b/tools/memory_tools.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-"""LangChain tool exposing :func:`services.clear_rag_memory.clear_memory`."""
+"""LangChain tool exposing :func:`services.clear_memory`."""
 
 from langchain.tools import Tool
 
-from services.clear_rag_memory import clear_memory
+from services import clear_memory
 
 
 def _clear(mem: str = "all") -> str:

--- a/tools/output_reader.py
+++ b/tools/output_reader.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from langchain.tools import Tool
-from services.output_reader import list_output_files, read_output_file
+from services import list_output_files, read_output_file
 
 
 def _list() -> str:

--- a/tools/self_inspection_tool.py
+++ b/tools/self_inspection_tool.py
@@ -1,9 +1,9 @@
-"""LangChain tool exposing services.self_inspection.agent_introspect."""
+"""LangChain tool exposing :func:`services.agent_introspect`."""
 from __future__ import annotations
 
 from langchain.tools import Tool
 
-from services.self_inspection import agent_introspect
+from services import agent_introspect
 
 
 self_inspection_tool = Tool(


### PR DESCRIPTION
## Summary
- link all tools to services via the service package
- expose `clear_memory`, `update_kb` and `agent_introspect` from the service layer
- clean up service exports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6880ef9ab8148330b2abb8f04c648fcf