### PR TITLE
Refactor scheduler init and incremental snapshots

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -8,10 +8,12 @@ handle_query = core.handle_query
 handle_query_stream = core.handle_query_stream
 agent_workflow = core.agent_workflow
 ResearchResponse = core.ResearchResponse
+start_background_jobs = core.start_background_jobs
  
 __all__ = [
      "handle_query",
      "handle_query_stream",
-     "agent_workflow",
-     "ResearchResponse",
+    "agent_workflow",
+    "ResearchResponse",
+    "start_background_jobs",
     ]

--- a/agent/core.py
+++ b/agent/core.py
@@ -281,38 +281,70 @@ threading.Thread(target=_ensure_cache, daemon=True).start()
 # ---------------------------------------------------------------------------
 # Periodic snapshotting of chat memory
 # ---------------------------------------------------------------------------
-SNAPSHOT_PATH = os.getenv("CHAT_SNAPSHOT_FILE", "data/chat_snapshot.parquet")
+SNAPSHOT_PATH = os.getenv("CHAT_SNAPSHOT_FILE", "data/chat_snapshot.jsonl")
 SNAPSHOT_INTERVAL = int(os.getenv("CHAT_SNAPSHOT_INTERVAL", 600))
 
 
-def _snapshot_chat() -> None:
-    """Persist chat vectors and metadata to a Parquet file."""
+def _snapshot_chat(path: str = SNAPSHOT_PATH, mask_pii: bool = False) -> None:
+    """Append new chat records to a JSONL snapshot."""
     try:
+        last_ts = None
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    pass
+                if line:
+                    try:
+                        last_ts = json.loads(line).get("ts")
+                    except Exception:
+                        last_ts = None
+
         data = _chat_store.get(include=["documents", "metadatas"], limit=None)
-        rows = [
-            {
-                "id": i,
-                "document": doc,
-                **(meta or {}),
-            }
-            for i, doc, meta in zip(
-                data.get("ids", []),
-                data.get("documents", []),
-                data.get("metadatas", []),
-            )
-        ]
+        rows = []
+        for i, doc, meta in zip(
+            data.get("ids", []),
+            data.get("documents", []),
+            data.get("metadatas", []),
+        ):
+            ts = (meta or {}).get("ts")
+            if last_ts and ts and ts <= last_ts:
+                continue
+            if mask_pii:
+                from utils.redaction import redact_pii
+
+                doc = redact_pii(doc)
+            rows.append({"id": i, "document": doc, **(meta or {})})
+
         if rows:
-            os.makedirs(os.path.dirname(SNAPSHOT_PATH), exist_ok=True)
-            pd.DataFrame(rows).to_parquet(SNAPSHOT_PATH, index=False)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "a", encoding="utf-8") as f:
+                for row in rows:
+                    json.dump(row, f, ensure_ascii=False)
+                    f.write("\n")
     except Exception:
         pass
 
 
-_scheduler = BackgroundScheduler(daemon=True)
-_scheduler.add_job(_snapshot_chat, "interval", seconds=SNAPSHOT_INTERVAL)
-_scheduler.start()
-atexit.register(lambda: _scheduler.shutdown(wait=False))
-atexit.register(_snapshot_chat)
+_scheduler: BackgroundScheduler | None = None
+
+
+def start_background_jobs(config: dict | None = None) -> BackgroundScheduler:
+    """Start background tasks like periodic snapshotting."""
+    global _scheduler
+    if _scheduler is not None:
+        return _scheduler
+
+    cfg = config or {}
+    interval = int(cfg.get("snapshot_interval", SNAPSHOT_INTERVAL))
+    path = cfg.get("snapshot_path", SNAPSHOT_PATH)
+    mask = bool(cfg.get("mask_pii", False))
+
+    _scheduler = BackgroundScheduler(daemon=True)
+    _scheduler.add_job(_snapshot_chat, "interval", seconds=interval, args=(path, mask))
+    _scheduler.start()
+    atexit.register(lambda: _scheduler.shutdown(wait=False))
+    atexit.register(lambda: _snapshot_chat(path, mask))
+    return _scheduler
 
 
 def _ev_attr(ev, attr: str, default=None):
@@ -839,4 +871,10 @@ async def handle_query_stream(query: str):
 # Convenience alias pro případné externí diagnostiky
 agent_workflow = workflow
 
-__all__ = ["handle_query", "handle_query_stream", "agent_workflow", "ResearchResponse"]
+__all__ = [
+    "handle_query",
+    "handle_query_stream",
+    "agent_workflow",
+    "ResearchResponse",
+    "start_background_jobs",
+]

--- a/run.py
+++ b/run.py
@@ -1,5 +1,14 @@
 """Compatibility wrapper for the Gradio UI entry point."""
 from cli.ui import launch
+import os
+from agent import start_background_jobs
 
 if __name__ == "__main__":
+    start_background_jobs(
+        {
+            "snapshot_interval": int(os.getenv("CHAT_SNAPSHOT_INTERVAL", 600)),
+            "snapshot_path": os.getenv("CHAT_SNAPSHOT_FILE", "data/chat_snapshot.jsonl"),
+            "mask_pii": os.getenv("CHAT_SNAPSHOT_MASK_PII", "false").lower() in {"1", "true", "yes"},
+        }
+    )
     launch()

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.redaction import redact_pii
+
+
+def test_redact_email():
+    assert redact_pii("Contact test@example.com") == "Contact [REDACTED_EMAIL]"
+
+
+def test_redact_phone():
+    assert redact_pii("Call +420 123 456 789") == "Call [REDACTED_PHONE]"
+
+
+def test_no_pii():
+    text = "Hello world"
+    assert redact_pii(text) == text

--- a/utils/redaction.py
+++ b/utils/redaction.py
@@ -1,0 +1,11 @@
+import re
+
+EMAIL_RE = re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+")
+PHONE_RE = re.compile(r"\+?\d[\d\s.-]{7,}\d")
+
+
+def redact_pii(text: str) -> str:
+    """Mask simple PII patterns like emails and phone numbers in ``text``."""
+    text = EMAIL_RE.sub("[REDACTED_EMAIL]", text)
+    text = PHONE_RE.sub("[REDACTED_PHONE]", text)
+    return text


### PR DESCRIPTION
## Summary
- avoid side effects when importing `agent.core`
- create `start_background_jobs()` to manage scheduler startup
- write incremental chat snapshots with optional PII masking
- expose simple regex based PII redaction utility
- call background job starter from `run.py`
- add unit tests for redaction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888993c15108330a7ecd93210872fda