### PR TITLE
Add rotating history with indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Conversational assistant tailored for **Productoo's P4** platform. It leverages 
 | **Content generators** | Create Jira Ideas, Epics and User Stories from short prompts. |
 | **File ingestion** | Drop files into `./files` and import them with `process_input_files` or `kb_loader`. |
 | **File editing** | Edit, rename and delete text files directly from the web UI. |
-| **Persistent memory** | Chat history saved to `data/persistent_chat_history.json` and stored in the vector DB. |
+| **Persistent memory** | Chat history saved to `data/persistent_chat_history.json` (rotated every 5 MB) and stored in the vector DB. |
 
 ---
 
@@ -82,7 +82,7 @@ Key environment options:
 
 - `CHROMA_DIR_V2` – path to the Chroma persistence directory (default `data/`).
 - `AGENT_VERSION` – set to `v1` to use the older LangChain core; default `v2` uses LangGraph.
-- `PERSISTENT_HISTORY_FILE` – JSON file storing chat history (default `data/persistent_chat_history.json`).
+- `PERSISTENT_HISTORY_FILE` – JSON file storing chat history (default `data/persistent_chat_history.json`, rotated after 5 MB).
 
 ---
 

--- a/agent/core.py
+++ b/agent/core.py
@@ -32,6 +32,7 @@ import openai
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain.memory import ConversationBufferWindowMemory
 from langchain_community.chat_message_histories import FileChatMessageHistory
+from utils.rotating_history import RotatingFileChatMessageHistory
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain.schema import Document
@@ -209,11 +210,11 @@ _persistent_history_file = Path(
 )
 _persistent_history_file.parent.mkdir(parents=True, exist_ok=True)
 
-_short_term_memory.chat_memory = FileChatMessageHistory(
+_short_term_memory.chat_memory = RotatingFileChatMessageHistory(
     file_path=str(_persistent_history_file)
 )
 
-_short_term_memory.chat_memory = FileChatMessageHistory(
+_short_term_memory.chat_memory = RotatingFileChatMessageHistory(
     file_path=_persistent_history_file
 )
 

--- a/tests/test_rotating_history.py
+++ b/tests/test_rotating_history.py
@@ -1,0 +1,29 @@
+import pathlib
+import sys
+import json
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.rotating_history import RotatingFileChatMessageHistory
+from langchain.schema import HumanMessage
+
+
+def test_rotation(tmp_path):
+    path = tmp_path / "history.json"
+    hist = RotatingFileChatMessageHistory(path, max_mb=0.0001)
+    big_msg = "x" * 2048
+    for _ in range(3):
+        hist.add_message(HumanMessage(content=big_msg))
+    rotated = [p for p in tmp_path.glob("history_*.json") if p.name != "history.json"]
+    assert len(rotated) >= 1
+    assert path.exists()
+
+
+def test_indexing(tmp_path):
+    path = tmp_path / "history.json"
+    hist = RotatingFileChatMessageHistory(path, max_mb=1)
+    hist.add_message(HumanMessage(content="hi", additional_kwargs={"timestamp": "t1", "session_id": "s"}))
+    idx = path.with_suffix('.idx')
+    data = json.loads(idx.read_text())
+    assert data["timestamp"]["t1"] == 0
+    assert "s" in data["session_id"]

--- a/utils/rotating_history.py
+++ b/utils/rotating_history.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, List
+
+from langchain_community.chat_message_histories import FileChatMessageHistory
+from langchain.schema import BaseMessage
+from langchain.schema.messages import messages_from_dict, messages_to_dict
+
+
+class RotatingFileChatMessageHistory(FileChatMessageHistory):
+    """File-based chat history with simple size-based rotation and indexes."""
+
+    def __init__(
+        self,
+        file_path: str | Path,
+        *,
+        encoding: Optional[str] = None,
+        ensure_ascii: bool = True,
+        max_mb: int = 5,
+    ) -> None:
+        self.max_bytes = max_mb * 1024 * 1024
+        self.file_path = Path(file_path)
+        self.encoding = encoding
+        self.ensure_ascii = ensure_ascii
+        self.index_path = self.file_path.with_suffix(".idx")
+
+        if not self.file_path.exists():
+            self.file_path.parent.mkdir(parents=True, exist_ok=True)
+            self.file_path.write_text(
+                json.dumps([], ensure_ascii=self.ensure_ascii), encoding=self.encoding
+            )
+        if not self.index_path.exists():
+            self.index_path.write_text(
+                json.dumps({"timestamp": {}, "session_id": {}}, ensure_ascii=self.ensure_ascii),
+                encoding=self.encoding,
+            )
+        self._load_index()
+
+    def _load_index(self) -> None:
+        try:
+            self._index = json.loads(self.index_path.read_text(encoding=self.encoding))
+        except Exception:
+            self._index = {"timestamp": {}, "session_id": {}}
+
+    def _save_index(self) -> None:
+        self.index_path.write_text(
+            json.dumps(self._index, ensure_ascii=self.ensure_ascii),
+            encoding=self.encoding,
+        )
+
+    def _rotate(self) -> None:
+        ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        rotated = self.file_path.with_name(f"{self.file_path.stem}_{ts}{self.file_path.suffix}")
+        rotated_idx = rotated.with_suffix(".idx")
+        os.rename(self.file_path, rotated)
+        os.rename(self.index_path, rotated_idx)
+        self.file_path.write_text(
+            json.dumps([], ensure_ascii=self.ensure_ascii), encoding=self.encoding
+        )
+        self.index_path.write_text(
+            json.dumps({"timestamp": {}, "session_id": {}}, ensure_ascii=self.ensure_ascii),
+            encoding=self.encoding,
+        )
+        self._index = {"timestamp": {}, "session_id": {}}
+
+    @property
+    def messages(self) -> List[BaseMessage]:  # type: ignore[override]
+        items = json.loads(self.file_path.read_text(encoding=self.encoding))
+        return messages_from_dict(items)
+
+    def add_message(self, message: BaseMessage) -> None:
+        messages = messages_to_dict(self.messages)
+        record = messages_to_dict([message])[0]
+        messages.append(record)
+        self.file_path.write_text(
+            json.dumps(messages, ensure_ascii=self.ensure_ascii), encoding=self.encoding
+        )
+        meta = record.get("data", {}).get("additional_kwargs", {})
+        ts = meta.get("timestamp")
+        sid = meta.get("session_id")
+        pos = len(messages) - 1
+        if ts is not None:
+            self._index["timestamp"][ts] = pos
+        if sid is not None:
+            self._index["session_id"].setdefault(sid, []).append(pos)
+        self._save_index()
+        if self.file_path.stat().st_size > self.max_bytes:
+            self._rotate()
+
+    def clear(self) -> None:  # type: ignore[override]
+        self.file_path.write_text(
+            json.dumps([], ensure_ascii=self.ensure_ascii), encoding=self.encoding
+        )
+        self._index = {"timestamp": {}, "session_id": {}}
+        self._save_index()


### PR DESCRIPTION
## Summary
- implement `RotatingFileChatMessageHistory` with 5 MB file rotation
- store timestamp and session_id indexes for the chat log
- use the new history class in the agent
- document rotation behaviour
- add regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68889cf7a5288330a932562c577e9b5e