### PR TITLE
Fix duplicated chat_memory setup

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -210,10 +210,6 @@ _persistent_history_file = Path(
 _persistent_history_file.parent.mkdir(parents=True, exist_ok=True)
 
 _short_term_memory.chat_memory = FileChatMessageHistory(
-    file_path=str(_persistent_history_file)
-)
-
-_short_term_memory.chat_memory = FileChatMessageHistory(
     file_path=_persistent_history_file
 )
 

--- a/tests/test_memory_initialization.py
+++ b/tests/test_memory_initialization.py
@@ -1,0 +1,17 @@
+import ast
+import pathlib
+
+
+def test_chat_memory_initialized_once():
+    source = pathlib.Path("agent/core.py").read_text()
+    tree = ast.parse(source)
+    assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Attribute)
+        and getattr(target.value, "id", "") == "_short_term_memory"
+        and target.attr == "chat_memory"
+    ]
+    assert len(assignments) == 1


### PR DESCRIPTION
## Summary
- remove double initialization of `_short_term_memory.chat_memory`
- add regression test ensuring the chat memory is assigned once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68889d7245d88330b4b7ac3c9a86ef03